### PR TITLE
Find by Id using Like fix

### DIFF
--- a/server/.env.dev
+++ b/server/.env.dev
@@ -1,6 +1,6 @@
 DB_URL=mongodb://localhost:27017/opencoronavirus
 DB_USER=
-DB_PASS=
+DB_PASSWORD=
 DB_NAME=opencoronavirus
 PORT=3000
 

--- a/server/.env.production
+++ b/server/.env.production
@@ -1,5 +1,5 @@
 DB_NAME=opencoronavirus
 DB_URL=mongodb+srv://admin:secret@your-prod-server
-DB_PASS=secret
+DB_PASSWORD=secret
 DB_USER=admin
 PORT=9050

--- a/server/.gitignore
+++ b/server/.gitignore
@@ -23,3 +23,4 @@ npm-debug.log*
 /.vscode
 /coverage
 /node_modules
+/dist

--- a/server/package.json
+++ b/server/package.json
@@ -32,7 +32,7 @@
     "docker:run": "docker run -p 3000:3000 -d adminapp-server",
     "migrate": "node ./dist/migrate",
     "prestart": "npm run build",
-    "start": "NODE_ENV=dev node -r source-map-support/register .",
+    "start": "NODE_ENV=dev DEBUG=loopback:connector:mongodb node -r source-map-support/register .",
     "prepublishOnly": "npm run test"
   },
   "repository": {

--- a/server/src/controllers/leave-request.controller.ts
+++ b/server/src/controllers/leave-request.controller.ts
@@ -143,9 +143,9 @@ export class LeaveRequestController {
   })
   async findByToken(
     @param.path.string('token') token: string,
-  ): Promise<LeaveRequest[]> {
-    let filter: Filter<LeaveRequest> = {"where": {"patientId":{"like":token}}, order: ['outOfHomeTimestamp DESC'], limit: 1};
-    return this.leaveRequestRepository.find(filter);
+  ): Promise<LeaveRequest | null> {
+    let filter: Filter<LeaveRequest> = {"where": {"patientId":token}, order: ['outOfHomeTimestamp DESC']};
+    return this.leaveRequestRepository.findOne(filter, {strictObjectIDCoercion: true});
   }
 
   @put('/leave-requests/token/{token}/set-at-home', {
@@ -159,14 +159,14 @@ export class LeaveRequestController {
     @param.path.string('token') token: string
   ): Promise<void> {
 
-    let filter: Filter<LeaveRequest> =  {"where": {"patientId":{"like":token}}, order: ['outOfHomeTimestamp DESC'], limit: 1};
-    await this.leaveRequestRepository.find(filter).then(result => {
-      if(result.length > 0) {
-        let leaveRequest = result[0];
-        leaveRequest.status = 1;
-        this.leaveRequestRepository.save(leaveRequest);
-      }
-    });
+    let filter: Filter<LeaveRequest> =  {"where": {"patientId":token}, order: ['outOfHomeTimestamp DESC']};
+    await this.leaveRequestRepository.findOne(filter, {strictObjectIDCoercion: true})
+      .then(leaveRequest => {
+        if(leaveRequest) {
+          leaveRequest.status = 1;
+          this.leaveRequestRepository.save(leaveRequest);
+        }
+      });
 
   }
 
@@ -181,15 +181,15 @@ export class LeaveRequestController {
     @param.path.string('token') token: string
   ): Promise<void> {
 
-    let filter: Filter<LeaveRequest> = {"where": {"patientId":{"like":token}}, order: ['outOfHomeTimestamp DESC'], limit: 1};
-    await this.leaveRequestRepository.find(filter).then(result => {
-      if(result.length > 0) {
-        let leaveRequest = result[0];
-        leaveRequest.backToHomeTimestamp = new Date();
-        leaveRequest.status = 2;
-        this.leaveRequestRepository.save(leaveRequest);
-      }
-    });
+    let filter: Filter<LeaveRequest> = {"where": {"patientId":token}, order: ['outOfHomeTimestamp DESC']};
+    await this.leaveRequestRepository.findOne(filter, {strictObjectIDCoercion: true})
+      .then(leaveRequest => {
+        if(leaveRequest) {
+          leaveRequest.backToHomeTimestamp = new Date();
+          leaveRequest.status = 2;
+          this.leaveRequestRepository.save(leaveRequest);
+        }
+      });
 
   }
 

--- a/server/src/controllers/test-appointment.controller.ts
+++ b/server/src/controllers/test-appointment.controller.ts
@@ -53,11 +53,11 @@ export class TestAppointmentController {
     ): Promise<TestAppointment> {
 
         let returnValue: Promise<TestAppointment> = new Promise(resolve => {
-
-            this.testResultRepository.findOne({
-                where: {patientId: {like: testAppointment.patientId}},
-                order: ['created DESC']
-            }).then(testResult => {
+          this.testResultRepository.findOne({
+            where: {patientId: testAppointment.patientId},
+            order: ['created DESC']
+          }, {strictObjectIDCoercion: true})
+            .then(testResult => {
                 switch (testResult?.action) {
                     case TestActionEnum.SCHEDULE_TEST_APPOINTMENT_AT_HEALTH_CENTER:
                         testAppointment.type = AppointmentType.AT_HEALTH_CENTER;
@@ -196,12 +196,11 @@ export class TestAppointmentController {
     async findLatestByPatientId(
         @param.path.string('patientId') patientId: string
     ): Promise<TestAppointment | null> {
-
         return this.testAppointmentRepository.findOne({
-            where: {patientId: {like: patientId}},
+            where: {patientId: patientId},
             include: [{relation: 'healthCenter'}],
             order: ['created DESC']
-        });
+        }, {strictObjectIDCoercion: true});
 
     }
 

--- a/server/src/controllers/test-result.controller.ts
+++ b/server/src/controllers/test-result.controller.ts
@@ -190,7 +190,9 @@ export class TestResultController {
         @param.path.string('patientId') patientId: string
     ): Promise<TestResult | null> {
 
-        return this.testResultRepository.findOne({where: {patientId: {like: patientId}}, order: ['created DESC']});
+        return this.testResultRepository.findOne(
+          {where: {patientId: patientId}, order: ['created DESC']},
+          {strictObjectIDCoercion: true});
 
     }
 


### PR DESCRIPTION
Fixes #8 

So basically the gist of the problem is this issue in the Loopback repo:

https://github.com/strongloop/loopback-next/issues/3720

(tldr; Loopback isn't great at managing mongo's objectId type)

After reading about the original issue here (https://github.com/strongloop/loopback-next/issues/1875) and not having any success with the workaround described there, I found the quickest fix was to add the `strictObjectIDCoercion` flag (documented here https://loopback.io/doc/en/lb3/MongoDB-connector.html#strictobjectidcoercion-flag) to all queries that need to match mongo ids as fks (which are stored as strings in the DB) - so this is something that needs to be taken into account moving forward.

The PR also fixes a few issues I found related to the set up of the server project:

- Added DEBUG=loopback:connector:mongodb to npm start, very useful to check the actual queries that the mongodb connector is running
- Fixed a typo in the server .env files, `DB_PASS` => `DB_PASSWORD` as is expected in `mongo.datasources.ts` file
- Added the server `/dist` folder to .gitignore file